### PR TITLE
Add property to access, in IInvocationInfo, the underlying target class method, if the proxy is an interface.

### DIFF
--- a/src/LightInject.Interception.Tests/InterceptorTests.cs
+++ b/src/LightInject.Interception.Tests/InterceptorTests.cs
@@ -61,6 +61,26 @@ namespace LightInject.Interception.Tests
 
             firstInterceptorMock.Verify(i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == method)));
         }
+        
+        [Fact]
+        public void Execute_CompositeInterceptor_PassesMethodInvocationTargetToInterceptor()
+        {
+            var firstInterceptorMock = new Mock<IInterceptor>();
+            var secondInterceptorMock = new Mock<IInterceptor>();
+            var invocationMock = new Mock<IInvocationInfo>();
+            var method = typeof(IMethodWithNoParameters).GetMethods()[0];
+
+            invocationMock.SetupGet(i => i.MethodInvocationTarget).Returns(method);
+            var compositeInterceptor = new CompositeInterceptor(new[]
+                                                                    {
+                                                                        new Lazy<IInterceptor>(() => firstInterceptorMock.Object),
+                                                                        new Lazy<IInterceptor>(() => secondInterceptorMock.Object),
+                                                                    });
+
+            compositeInterceptor.Invoke(invocationMock.Object);
+
+            firstInterceptorMock.Verify(i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.MethodInvocationTarget == method)));
+        }        
 
         [Fact]
         public void Execute_CompositeInterceptor_PassesArgumentsToInterceptor()

--- a/src/LightInject.Interception.Tests/ProxyBuilderTests.cs
+++ b/src/LightInject.Interception.Tests/ProxyBuilderTests.cs
@@ -273,7 +273,35 @@ namespace LightInject.Interception.Tests
 
             interceptorMock.Verify(
                 i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethod)));
-        }    
+        }
+        
+        [Fact]
+        public void Execute_GenericMethod_PassesMethodInvocationTargetInfoToInterceptorWhenProxyIsInterface()
+        {
+            var interceptorMock = new Mock<IInterceptor>();
+            var instance = CreateProxy<IMethodWithGenericParameter, MethodWithGenericParameter>(interceptorMock.Object, "Execute");
+            MethodInfo expectedMethod = typeof(IMethodWithGenericParameter).GetMethod("Execute").MakeGenericMethod(typeof(int));
+            MethodInfo expectedMethodInvocationTarget = typeof(MethodWithGenericParameter).GetMethod("Execute").MakeGenericMethod(typeof(int));
+
+            instance.Execute<int>(0);
+
+            interceptorMock.Verify(
+                i => i.Invoke(
+                    It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethodInvocationTarget)));
+        }        
+        
+        [Fact]
+        public void Execute_GenericMethod_PassesMethodInvocationTargetInfoToInterceptorWhenProxyIsNotInterface()
+        {
+            var interceptorMock = new Mock<IInterceptor>();
+            var instance = CreateProxy<IMethodWithGenericParameter>(interceptorMock.Object);
+            MethodInfo expectedMethod = typeof(IMethodWithGenericParameter).GetMethod("Execute").MakeGenericMethod(typeof(int));
+
+            instance.Execute<int>(0);
+
+            interceptorMock.Verify(
+                i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethod)));
+        }
        
         [Fact]
         public void Execute_NonGenericMethod_PassesProxyInstanceToInterceptor()

--- a/src/LightInject.Interception.Tests/ProxyBuilderTests.cs
+++ b/src/LightInject.Interception.Tests/ProxyBuilderTests.cs
@@ -246,6 +246,34 @@ namespace LightInject.Interception.Tests
 
             interceptorMock.Verify(i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod)));
         }
+        
+        [Fact]
+        public void Execute_NonGenericMethod_PassesMethodInvocationTargetInfoToInterceptorWhenProxyIsInterface()
+        {
+            var interceptorMock = new Mock<IInterceptor>();
+            var instance = CreateProxy<IClassWithOneMethod, ClassWithOneMethod>(interceptorMock.Object, "FirstMethod");
+            MethodInfo expectedMethod = typeof(IClassWithOneMethod).GetMethod("FirstMethod");
+            MethodInfo expectedMethodInvocationTarget = typeof(ClassWithOneMethod).GetMethod("FirstMethod");
+            
+            instance.FirstMethod();
+
+            interceptorMock.Verify(
+                i => i.Invoke(
+                    It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethodInvocationTarget)));
+        }
+        
+        [Fact]
+        public void Execute_NonGenericMethod_PassesMethodInvocationTargetInfoToInterceptorWhenProxyIsNotInterface()
+        {
+            var interceptorMock = new Mock<IInterceptor>();
+            var instance = CreateProxy<IMethodWithNoParameters>(interceptorMock.Object);
+            MethodInfo expectedMethod = typeof(IMethodWithNoParameters).GetMethod("Execute");
+
+            instance.Execute();
+
+            interceptorMock.Verify(
+                i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethod)));
+        }    
        
         [Fact]
         public void Execute_NonGenericMethod_PassesProxyInstanceToInterceptor()
@@ -914,6 +942,14 @@ namespace LightInject.Interception.Tests
             Type proxyType = CreateProxyBuilder().GetProxyType(proxyDefinition);
             return (T)Activator.CreateInstance(proxyType, (object)null);
         }
+        
+        private T1 CreateProxy<T1, T2>(IInterceptor interceptor, string methodName)
+        {
+            var proxyDefinition = new ProxyDefinition(typeof(T1), typeof(T2), false);
+            proxyDefinition.Implement(() => interceptor, info => info.Name == methodName);
+            Type proxyType = CreateProxyBuilder().GetProxyType(proxyDefinition);
+            return (T1)Activator.CreateInstance(proxyType, (object)null);
+        }        
 
         private T CreateProxy<T>(T target)
         {

--- a/src/LightInject.Interception.Tests/SampleInterfaces.cs
+++ b/src/LightInject.Interception.Tests/SampleInterfaces.cs
@@ -225,6 +225,14 @@ namespace LightInject.Interception.Tests
     {
         void Execute<T>(T value);
     }
+    
+    public class MethodWithGenericParameter: IMethodWithGenericParameter
+    {
+        public void Execute<T>(T value)
+        {
+            
+        }
+    }
 
     public interface IDerivedFromGenericMethod : IMethodWithGenericParameter
     {


### PR DESCRIPTION
Hi!

I was trying to address this issue: https://github.com/seesharper/LightInject.Interception/issues/17

It seemed to me that it would be nice to have access, inside IInvocationInfo, to the target method of the concrete class, if the proxy is an interface: like Castle's Dynamic proxy allows to do (see property MethodInvocationTarget on https://github.com/castleproject/Core/blob/master/src/Castle.Core/DynamicProxy/IInvocation.cs).

With this change, now I can test, inside the interceptor, for a custom attribute in the class:

```c#
public class MySimpleInterceptor : IInterceptor
{
    public object Invoke(IInvocationInfo invocationInfo)
    {
        bool hasCustomAttribute = invocationInfo.MethodInvocationTarget.GetCustomAttribute<MyCustomAttribute>() != null;
        // ...           
    }
}
```

I doubt my implementation is correct: let me know if there's something that it could be done better.

Thanks!