### PR TITLE
Prepare release 2.0.2

### DIFF
--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -8,7 +8,6 @@ var root = FileUtils.GetScriptFolder();
 var solutionFolder = Path.Combine(root,"..","src");
 var projectFolder = Path.Combine(root, "..", "src", "LightInject.Interception");
 
-
 var testProjectFolder = Path.Combine(root, "..", "src", "LightInject.Interception.Tests");
 
 var pathToTestAssembly = Path.Combine(testProjectFolder, "bin","release", "net46", "LightInject.Interception.Tests.dll");

--- a/src/LightInject.Interception.Tests/InterceptorTests.cs
+++ b/src/LightInject.Interception.Tests/InterceptorTests.cs
@@ -70,7 +70,7 @@ namespace LightInject.Interception.Tests
             var invocationMock = new Mock<IInvocationInfo>();
             var method = typeof(IMethodWithNoParameters).GetMethods()[0];
 
-            invocationMock.SetupGet(i => i.MethodInvocationTarget).Returns(method);
+            invocationMock.SetupGet(i => i.TargetMethod).Returns(method);
             var compositeInterceptor = new CompositeInterceptor(new[]
                                                                     {
                                                                         new Lazy<IInterceptor>(() => firstInterceptorMock.Object),
@@ -79,7 +79,7 @@ namespace LightInject.Interception.Tests
 
             compositeInterceptor.Invoke(invocationMock.Object);
 
-            firstInterceptorMock.Verify(i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.MethodInvocationTarget == method)));
+            firstInterceptorMock.Verify(i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.TargetMethod == method)));
         }        
 
         [Fact]

--- a/src/LightInject.Interception.Tests/ProxyBuilderTests.cs
+++ b/src/LightInject.Interception.Tests/ProxyBuilderTests.cs
@@ -259,7 +259,7 @@ namespace LightInject.Interception.Tests
 
             interceptorMock.Verify(
                 i => i.Invoke(
-                    It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethodInvocationTarget)));
+                    It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.TargetMethod == expectedMethodInvocationTarget)));
         }
         
         [Fact]
@@ -272,7 +272,7 @@ namespace LightInject.Interception.Tests
             instance.Execute();
 
             interceptorMock.Verify(
-                i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethod)));
+                i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.TargetMethod == expectedMethod)));
         }
         
         [Fact]
@@ -287,7 +287,7 @@ namespace LightInject.Interception.Tests
 
             interceptorMock.Verify(
                 i => i.Invoke(
-                    It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethodInvocationTarget)));
+                    It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.TargetMethod == expectedMethodInvocationTarget)));
         }        
         
         [Fact]
@@ -300,7 +300,7 @@ namespace LightInject.Interception.Tests
             instance.Execute<int>(0);
 
             interceptorMock.Verify(
-                i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.MethodInvocationTarget == expectedMethod)));
+                i => i.Invoke(It.Is<IInvocationInfo>(ii => ii.Method == expectedMethod && ii.TargetMethod == expectedMethod)));
         }
        
         [Fact]

--- a/src/LightInject.Interception/LightInject.Interception.cs
+++ b/src/LightInject.Interception/LightInject.Interception.cs
@@ -204,7 +204,7 @@ namespace LightInject.Interception
         /// <summary>
         /// If the proxy is an interface, gets the <see cref="MethodInfo"/> currently being invoked on the target class. 
         /// </summary>
-        MethodInfo MethodInvocationTarget { get; }
+        MethodInfo TargetMethod { get; }
 
         /// <summary>
         /// Gets the <see cref="IProxy"/> instance that intercepted the method call.
@@ -675,7 +675,7 @@ namespace LightInject.Interception
         /// <summary>
         /// If the proxy is an interface, gets the <see cref="MethodInfo"/> currently being invoked on the target class. 
         /// </summary>
-        public MethodInfo MethodInvocationTarget
+        public MethodInfo TargetMethod
         {
             get
             {
@@ -749,11 +749,11 @@ namespace LightInject.Interception
         /// <summary>
         /// If the proxy is an interface, gets the <see cref="MethodInfo"/> currently being invoked on the target class. 
         /// </summary>        
-        public MethodInfo MethodInvocationTarget
+        public MethodInfo TargetMethod
         {
             get
             {
-                return nextInvocationInfo.MethodInvocationTarget;
+                return nextInvocationInfo.TargetMethod;
             }
         }        
 

--- a/src/LightInject.Interception/LightInject.Interception.csproj
+++ b/src/LightInject.Interception/LightInject.Interception.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net46;netstandard1.1;netstandard2.0</TargetFrameworks>
-        <Version>2.0.1</Version>
+        <Version>2.0.2</Version>
         <Authors>Bernhard Richter</Authors>
         <PackageProjectUrl>http//www.lightinject.net</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Bumps the version to 2.0.2.
Also renamed the proposed `MethodInvocationTarget` property to `TargetMethod` 
