### PR TITLE
Use GetRuntimeInterfaceMap to properly map methods in inherited classes (#21)

### DIFF
--- a/src/LightInject.Interception.Tests/ContainerInterceptionTests.cs
+++ b/src/LightInject.Interception.Tests/ContainerInterceptionTests.cs
@@ -178,6 +178,24 @@ namespace LightInject.Interception.Tests
         }
 
         [Fact]
+        public void Intercept_InheritedClassWithoutOverride_InvokesBase()
+        {
+            var container = new ServiceContainer();
+            container.Register<ITargetWithMethod, InheritedTargetWithoutOverride>();
+            container.Intercept(sr => sr.ServiceType == typeof(ITargetWithMethod), factory => new SampleInterceptor());
+            Assert.Equal(nameof(BaseTarget), container.GetInstance<ITargetWithMethod>().GetValue());
+        }
+
+        [Fact]
+        public void Intercept_InheritedClassWithOverride_InvokesInherited()
+        {
+            var container = new ServiceContainer();
+            container.Register<ITargetWithMethod, InheritedTargetWithOverride>();
+            container.Intercept(sr => sr.ServiceType == typeof(ITargetWithMethod), factory => new SampleInterceptor());
+            Assert.Equal(nameof(InheritedTargetWithOverride), container.GetInstance<ITargetWithMethod>().GetValue());
+        }
+
+        [Fact]
         public void issue_229()
         {
             var container = new ServiceContainer();

--- a/src/LightInject.Interception.Tests/SampleInterfaces.cs
+++ b/src/LightInject.Interception.Tests/SampleInterfaces.cs
@@ -29,6 +29,26 @@ namespace LightInject.Interception.Tests
         }
     }
 
+    public interface ITargetWithMethod
+    {
+        string GetValue();
+    }
+
+    public class BaseTarget : ITargetWithMethod
+    {
+        public virtual string GetValue() => nameof(BaseTarget);
+    }
+
+    public class InheritedTargetWithoutOverride : BaseTarget
+    {
+        // No method override
+    }
+
+    public class InheritedTargetWithOverride : BaseTarget
+    {
+        public override string GetValue() => nameof(InheritedTargetWithOverride);
+    }
+
 
     public interface IAdditionalInterface
     {

--- a/src/LightInject.Interception/LightInject.Interception.cs
+++ b/src/LightInject.Interception/LightInject.Interception.cs
@@ -1807,7 +1807,13 @@ namespace LightInject.Interception
 
             if (proxyDefinition.TargetType.GetTypeInfo().IsInterface && proxyDefinition.ImplementingType != null)
             {
-                targetInvocationMethod = proxyDefinition.ImplementingType.GetTypeInfo().DeclaredMethods.FirstOrDefault(m => m.Name == targetMethod.Name);
+                // TypeInfo.DeclaredMethods doesn't return methods implemented in base class
+                // Different methods can have the same name, with different parameter types
+                // GetRuntimeInterfaceMap correctly maps all implementation methods to interface methods
+                InterfaceMapping interfaceMapping =
+                    proxyDefinition.ImplementingType.GetTypeInfo().GetRuntimeInterfaceMap(targetMethod.DeclaringType);
+                int index = Array.IndexOf(interfaceMapping.InterfaceMethods, targetMethod);
+                targetInvocationMethod = interfaceMapping.TargetMethods[index];
             }
 
             if (targetMethod.IsGenericMethod)


### PR DESCRIPTION
Fix for issue #21.